### PR TITLE
Prevent touch-select of SVG in Firefox Android

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -51,6 +51,7 @@
 
       .card svg {
         stroke-width: 3px;
+        -moz-user-select: none;
       }
 
       .col0 svg {


### PR DESCRIPTION
Browser: firefox android
ISSUE: When selecting a card, if the user taps on the symbol svg, the browser brings up a contextual menu with "Select All"
https://imgur.com/a/EgAQIah